### PR TITLE
[wpa_supplicant] Re-enable WEP. JB#60571

### DIFF
--- a/rpm/build-config
+++ b/rpm/build-config
@@ -622,7 +622,7 @@ CONFIG_DPP2=y
 # functionality needed to use WEP is available in the current wpa_supplicant
 # release under this optional build parameter. This functionality is subject to
 # be completely removed in a future release.
-#CONFIG_WEP=y
+CONFIG_WEP=y
 
 # Remove all TKIP functionality
 # TKIP is an old cryptographic data confidentiality algorithm that is not


### PR DESCRIPTION
It's no good, but supporting it here doesn't cost much, and the earlier disabling didn't seem all concious decision, rather a side-effect on both upstream changing the default value and at the same time packaging changing the build config handling.

For comparison WEP is still enabled for Fedora and Android 13 I have for testing.

For Sailfish the proper removal should be done first on the UI level, which hasn't been done so far.