### PR TITLE
[wpa_supplicant] Enable timeout for scheduled scan. Fixes JB#62571

### DIFF
--- a/rpm/wpa_supplicant-Notify-scheduled-scan-stop-add-notify.patch
+++ b/rpm/wpa_supplicant-Notify-scheduled-scan-stop-add-notify.patch
@@ -1,0 +1,53 @@
+From 6ef99cf2902fcdfcbaa976bd5d85f080765c9f2f Mon Sep 17 00:00:00 2001
+From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
+Date: Wed, 11 Dec 2024 17:21:54 +0200
+Subject: [PATCH] wpa_supplicant: Notify scheduled scan stop, add notify
+ logging
+
+Add call to wpa_supplicant_notify_scanning() into
+wpa_supplicant_stop_sched_scan() to notify also the end of the scheduled
+scan. This is for upper layer components relying on the scan state to be
+able to trigger their own scan requests. Also add more logging for the
+scan start and stop notifies.
+
+Signed-off-by: Jussi Laakkonen <jussi.laakkonen@jolla.com>
+---
+ wpa_supplicant/scan.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/wpa_supplicant/scan.c b/wpa_supplicant/scan.c
+index 8b59e409b..34cbbc7d4 100644
+--- a/wpa_supplicant/scan.c
++++ b/wpa_supplicant/scan.c
+@@ -211,6 +211,8 @@ static void wpas_trigger_scan_cb(struct wpa_radio_work *work, int deinit)
+ 		return;
+ 	}
+ 
++	wpa_printf(MSG_DEBUG,
++			   "wpas_trigger_scan_cb notify scanning 1");
+ 	wpa_supplicant_notify_scanning(wpa_s, 1);
+ 
+ 	if (wpa_s->clear_driver_scan_cache) {
+@@ -372,6 +374,8 @@ wpa_supplicant_start_sched_scan(struct wpa_supplicant *wpa_s,
+ {
+ 	int ret;
+ 
++	wpa_printf(MSG_DEBUG,
++			   "wpa_supplicant_start_sched_scan notify scanning 1");
+ 	wpa_supplicant_notify_scanning(wpa_s, 1);
+ 	ret = wpa_drv_sched_scan(wpa_s, params);
+ 	if (ret)
+@@ -394,6 +398,10 @@ static int wpa_supplicant_stop_sched_scan(struct wpa_supplicant *wpa_s)
+ 		return -1;
+ 	}
+ 
++	wpa_printf(MSG_DEBUG,
++			   "wpa_supplicant_start_sched_scan notify scanning 0");
++	wpa_supplicant_notify_scanning(wpa_s, 0);
++
+ 	return ret;
+ }
+ 
+-- 
+2.39.2
+

--- a/rpm/wpa_supplicant-nl80211-Implement-support-for-scheduled-scan-timeout.patch
+++ b/rpm/wpa_supplicant-nl80211-Implement-support-for-scheduled-scan-timeout.patch
@@ -1,0 +1,154 @@
+From 4bf651e712ed5031eda928a8626fb629bf76faf0 Mon Sep 17 00:00:00 2001
+From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
+Date: Wed, 11 Dec 2024 17:06:04 +0200
+Subject: [PATCH] nl80211: Implement support for scheduled scan timeout
+
+Some drivers do start scheduled scan but never finish with the results.
+This timeout is equal to the scan timeout and behaves similarly, except
+the scan stopped event is sent when timeout is reached.
+
+Timeout will be started when the scheduled scan is initiated and
+canceled when the scan is stopped. Timeout itself is calculated
+similarly to the scan event timeout, ranging from 10s to 30s and for
+this a separate wpa_driver_nl80211_get_scan_timeout() is created to
+avoid code duplication.
+
+Signed-off-by: Jussi Laakkonen <jussi.laakkonen@jolla.com>
+---
+ src/drivers/driver_nl80211.h       |  3 ++
+ src/drivers/driver_nl80211_event.c |  9 +++++
+ src/drivers/driver_nl80211_scan.c  | 59 ++++++++++++++++++++++++------
+ 3 files changed, 60 insertions(+), 11 deletions(-)
+
+diff --git a/src/drivers/driver_nl80211.h b/src/drivers/driver_nl80211.h
+index 618746e67..4926c47ae 100644
+--- a/src/drivers/driver_nl80211.h
++++ b/src/drivers/driver_nl80211.h
+@@ -397,6 +397,9 @@ int wpa_driver_set_ap_wps_p2p_ie(void *priv, const struct wpabuf *beacon,
+ /* driver_nl80211_scan.c */
+ 
+ void wpa_driver_nl80211_scan_timeout(void *eloop_ctx, void *timeout_ctx);
++void wpa_driver_nl80211_scheduled_scan_timeout(void *eloop_ctx,
++			    void *timeout_ctx);
++int wpa_driver_nl80211_get_scan_timeout(struct wpa_driver_nl80211_data *drv);
+ int wpa_driver_nl80211_scan(struct i802_bss *bss,
+ 			    struct wpa_driver_scan_params *params);
+ int wpa_driver_nl80211_sched_scan(void *priv,
+diff --git a/src/drivers/driver_nl80211_event.c b/src/drivers/driver_nl80211_event.c
+index aee815e97..33169b93e 100644
+--- a/src/drivers/driver_nl80211_event.c
++++ b/src/drivers/driver_nl80211_event.c
+@@ -3858,6 +3858,7 @@ static void do_process_drv_event(struct i802_bss *bss, int cmd,
+ {
+ 	struct wpa_driver_nl80211_data *drv = bss->drv;
+ 	int external_scan_event = 0;
++	int timeout = 0;
+ 	struct nlattr *frame = tb[NL80211_ATTR_FRAME];
+ 
+ 	wpa_printf(MSG_DEBUG, "nl80211: Drv Event %d (%s) received for %s",
+@@ -3911,10 +3912,18 @@ static void do_process_drv_event(struct i802_bss *bss, int cmd,
+ 	case NL80211_CMD_START_SCHED_SCAN:
+ 		wpa_dbg(drv->ctx, MSG_DEBUG, "nl80211: Sched scan started");
+ 		drv->scan_state = SCHED_SCAN_STARTED;
++		eloop_cancel_timeout(wpa_driver_nl80211_scheduled_scan_timeout,
++				drv, drv->ctx);
++		timeout = wpa_driver_nl80211_get_scan_timeout(drv);
++		eloop_register_timeout(timeout, 0,
++				wpa_driver_nl80211_scheduled_scan_timeout, drv,
++				drv->ctx);
+ 		break;
+ 	case NL80211_CMD_SCHED_SCAN_STOPPED:
+ 		wpa_dbg(drv->ctx, MSG_DEBUG, "nl80211: Sched scan stopped");
+ 		drv->scan_state = SCHED_SCAN_STOPPED;
++		eloop_cancel_timeout(wpa_driver_nl80211_scheduled_scan_timeout,
++				drv, drv->ctx);
+ 		wpa_supplicant_event(drv->ctx, EVENT_SCHED_SCAN_STOPPED, NULL);
+ 		break;
+ 	case NL80211_CMD_NEW_SCAN_RESULTS:
+diff --git a/src/drivers/driver_nl80211_scan.c b/src/drivers/driver_nl80211_scan.c
+index b055e684a..65c75ef4e 100644
+--- a/src/drivers/driver_nl80211_scan.c
++++ b/src/drivers/driver_nl80211_scan.c
+@@ -173,6 +173,35 @@ void wpa_driver_nl80211_scan_timeout(void *eloop_ctx, void *timeout_ctx)
+ 	wpa_supplicant_event(timeout_ctx, EVENT_SCAN_RESULTS, NULL);
+ }
+ 
++void wpa_driver_nl80211_scheduled_scan_timeout(void *eloop_ctx,
++							void *timeout_ctx)
++{
++	struct wpa_driver_nl80211_data *drv = eloop_ctx;
++
++	wpa_printf(MSG_DEBUG, "nl80211: Sched scan timeout - try to abort it");
++
++#ifdef CONFIG_DRIVER_NL80211_QCA
++	if (drv->vendor_scan_cookie &&
++	    nl80211_abort_vendor_scan(drv, drv->vendor_scan_cookie) == 0)
++		return;
++#endif /* CONFIG_DRIVER_NL80211_QCA */
++	if (!drv->vendor_scan_cookie && nl80211_abort_scan(drv->first_bss) == 0)
++		return;
++
++	wpa_printf(MSG_DEBUG, "nl80211: Failed to abort sched scan");
++
++	if (drv->ap_scan_as_station != NL80211_IFTYPE_UNSPECIFIED)
++		nl80211_restore_ap_mode(drv->first_bss);
++
++	wpa_printf(MSG_DEBUG, "nl80211: Try to get sched scan results");
++	/* TODO use EVENT_SCAN_RESULTS for now, there isn't one for scheduled
++	 * scan results.*/
++	wpa_supplicant_event(timeout_ctx, EVENT_SCAN_RESULTS, NULL);
++
++	drv->scan_state = SCHED_SCAN_STOPPED;
++	wpa_printf(MSG_DEBUG, "nl80211: Send stop scheduled scan event");
++	wpa_supplicant_event(timeout_ctx, EVENT_SCHED_SCAN_STOPPED, NULL);
++}
+ 
+ static struct nl_msg *
+ nl80211_scan_common(struct i802_bss *bss, u8 cmd,
+@@ -333,6 +362,24 @@ fail:
+ 	return NULL;
+ }
+ 
++int wpa_driver_nl80211_get_scan_timeout(struct wpa_driver_nl80211_data *drv)
++{
++	int timeout = 0;
++
++	timeout = drv->uses_6ghz ? 20 : 10;
++	if (drv->uses_s1g)
++		timeout += 5;
++	if (drv->scan_complete_events) {
++		/*
++		 * The driver seems to deliver events to notify when scan is
++		 * complete, so use longer timeout to avoid race conditions
++		 * with scanning and following association request.
++		 */
++		timeout = 30;
++	}
++
++	return timeout;
++}
+ 
+ /**
+  * wpa_driver_nl80211_scan - Request the driver to initiate scan
+@@ -422,17 +469,7 @@ int wpa_driver_nl80211_scan(struct i802_bss *bss,
+ 	drv->scan_state = SCAN_REQUESTED;
+ 	/* Not all drivers generate "scan completed" wireless event, so try to
+ 	 * read results after a timeout. */
+-	timeout = drv->uses_6ghz ? 20 : 10;
+-	if (drv->uses_s1g)
+-		timeout += 5;
+-	if (drv->scan_complete_events) {
+-		/*
+-		 * The driver seems to deliver events to notify when scan is
+-		 * complete, so use longer timeout to avoid race conditions
+-		 * with scanning and following association request.
+-		 */
+-		timeout = 30;
+-	}
++	timeout = wpa_driver_nl80211_get_scan_timeout(drv);
+ 	wpa_printf(MSG_DEBUG, "Scan requested (ret=%d) - scan timeout %d "
+ 		   "seconds", ret, timeout);
+ 	eloop_cancel_timeout(wpa_driver_nl80211_scan_timeout, drv, drv->ctx);
+-- 
+2.39.2
+

--- a/rpm/wpa_supplicant.spec
+++ b/rpm/wpa_supplicant.spec
@@ -20,6 +20,9 @@ Patch4:     wpa_supplicant-quiet-scan-results-message.patch
 Patch5:     wpa_supplicant-allow-legacy-renegotiation.patch
 # From SUSE
 Patch6:     wpa_supplicant-sigusr1-changes-debuglevel.patch
+# SailfishOS
+Patch7:     wpa_supplicant-nl80211-Implement-support-for-scheduled-scan-timeout.patch
+Patch8:     wpa_supplicant-Notify-scheduled-scan-stop-add-notify.patch
 BuildRequires:  pkgconfig(libnl-3.0)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(openssl)


### PR DESCRIPTION
Add patches to address the non-stopped scheduled scan by sending the results after a timeout and stopping the scan itself. Seems to make the black network-issue on C2 to disappear. Also notify the scheduled scan stop always so libgsupplicant can deliver this info for ConnMan.