### PR TITLE
[wpa_supplicant] Enable sae_pwe=2 for all. JB#63948

### DIFF
--- a/rpm/wpa_supplicant-SAE-Set-default-sae_pwe-to-2-SAE_PWE_BOTH.patch
+++ b/rpm/wpa_supplicant-SAE-Set-default-sae_pwe-to-2-SAE_PWE_BOTH.patch
@@ -1,0 +1,28 @@
+From 60f96e8d327de688c935ab2a0ab4844d2a383292 Mon Sep 17 00:00:00 2001
+From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
+Date: Fri, 13 Mar 2026 18:39:38 +0200
+Subject: [PATCH] SAE: Set default sae_pwe to 2 (SAE_PWE_BOTH)
+
+The default, being unset, is equal to 0 in the config. Some WPA3
+networks require either of the HnP or H2E method to be used as the
+password-to-element method. Enable both for Sailfish OS.
+---
+ wpa_supplicant/config_ssid.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wpa_supplicant/config_ssid.h b/wpa_supplicant/config_ssid.h
+index 43a130530..80d8b96a1 100644
+--- a/wpa_supplicant/config_ssid.h
++++ b/wpa_supplicant/config_ssid.h
+@@ -47,7 +47,7 @@
+ #define DEFAULT_MAX_OPER_CHWIDTH -1
+ 
+ /* Consider global sae_pwe for SAE mechanism for PWE derivation */
+-#define DEFAULT_SAE_PWE SAE_PWE_NOT_SET
++#define DEFAULT_SAE_PWE SAE_PWE_BOTH
+ 
+ struct psk_list_entry {
+ 	struct dl_list list;
+-- 
+2.47.3
+

--- a/rpm/wpa_supplicant.spec
+++ b/rpm/wpa_supplicant.spec
@@ -25,6 +25,7 @@ Patch7:     wpa_supplicant-nl80211-Implement-support-for-scheduled-scan-timeout.
 Patch8:     wpa_supplicant-Notify-scheduled-scan-stop-add-notify.patch
 Patch9:     wpa_supplicant-nl80211-Set-NL80211_ATTR_SOCKET_OWNER-only-if-ker.patch
 Patch10:    wpa_supplicant-nl80211-Don-t-use-genl_ctrl_alloc_cache-on-kernels-o.patch
+Patch11:    wpa_supplicant-SAE-Set-default-sae_pwe-to-2-SAE_PWE_BOTH.patch
 BuildRequires:  pkgconfig(libnl-3.0)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(openssl)


### PR DESCRIPTION
Enable both HnP and H2E methods for all. This is not exposed as a D-Bus variable and it is a global variable. In https://git.w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf it is said to be enabled later anyways. Having H2E will increase compatibility with some WPA3 APs, thus we could enable this already.